### PR TITLE
Forked patch of error-printing

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -225,8 +225,12 @@ func Test() (err error) {
 				verdict = judge(i, "in%v.txt", "out%v.txt", s)
 			}
 
-			if verdict.err != nil && err != nil {
-				color.Red(err.Error())
+			if verdict.err != nil {
+				if err != nil {
+					color.Red(err.Error())
+				} else{
+					fmt.Print("Error is NULL\n")
+				}
 			} else {
 				fmt.Print(verdict.message)
 			}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -226,11 +226,7 @@ func Test() (err error) {
 			}
 
 			if verdict.err != nil {
-				if err != nil {
-					color.Red(err.Error())
-				} else{
-					fmt.Print("Error is NULL\n")
-				}
+				color.Red(verdict.err.Error())
 			} else {
 				fmt.Print(verdict.message)
 			}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -225,7 +225,7 @@ func Test() (err error) {
 				verdict = judge(i, "in%v.txt", "out%v.txt", s)
 			}
 
-			if verdict.err != nil {
+			if verdict.err != nil && err != nil {
 				color.Red(err.Error())
 			} else {
 				fmt.Print(verdict.message)


### PR DESCRIPTION
Whilst using it, I encountered an error, when if I had an incorrect configuration of a template, so that the script does not exist, I would face the error below. Quick patch fixed it to handle this correctly.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x9607ac]

goroutine 1 [running]:
github.com/Arapak/sio-tool/cmd.Test()
	/home/runner/work/sio-tool/sio-tool/cmd/test.go:229 +0x6ec
github.com/Arapak/sio-tool/cmd.Eval(0xc00001ae10?)
	/home/runner/work/sio-tool/sio-tool/cmd/cmd.go:33 +0x3f6
main.main()
	/home/runner/work/sio-tool/sio-tool/st.go:208 +0x333
```